### PR TITLE
add cache to webstat ajax request

### DIFF
--- a/js/components/core/load/init.js
+++ b/js/components/core/load/init.js
@@ -61,6 +61,7 @@
                 var webstatURI = win.location.protocol + "//www.dr.dk/drWebStat/drWebStat.js";
                 $.ajax({
                   url: webstatURI,
+                  cache: true,
                   dataType: "script",
                   error: function(xhr, ajaxOptions, thrownError) {
                     console.log("Error loading drwebstat", xhr.status, thrownError);


### PR DESCRIPTION
drtv for ikke cached webstats, muligvis andre sites er påvirket.
![jquery cachebuster](https://user-images.githubusercontent.com/16350399/33314667-a238fa16-d42e-11e7-80bd-c77a594f3863.png)

